### PR TITLE
Added sync command

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -48,11 +48,17 @@ class Config(commands.Cog):
         await self.config_controller.reload(interaction, cog)
         self.logger.info(f"Reloaded cogs")
 
-    @app_commands.command(description="Sync slash commands to discord")
-    @ConfigController.is_owner()
-    async def sync(self, interaction: discord.Interaction, option: Literal["Global", "Guild"]):
-        await self.config_controller.sync(interaction, option)
-        self.logger.info(f"Synced commands to {option}")
+    @commands.command()
+    @commands.guild_only()
+    @commands.is_owner()
+    async def sync(
+        self,
+        ctx: commands.Context,
+        guilds: commands.Greedy[discord.Object],
+        spec: Optional[Literal["~", "*", "^"]] = None,
+    ):
+        await self.config_controller.sync(ctx, guilds, spec)
+        self.logger.info("Synced commands")
 
 
 async def setup(bot: NationStatesBot):

--- a/nationstates_bot.py
+++ b/nationstates_bot.py
@@ -21,7 +21,6 @@ class NationStatesBot(commands.Bot):
         initial_extensions: List[str],
         db_pool: asyncpg.Pool,
         web_client: ClientSession,
-        testing_guild_id: Optional[int] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -33,21 +32,12 @@ class NationStatesBot(commands.Bot):
 
         self.nationstates_api = NationStatesAPI(self.web_client)
 
-        self.testing_guild_id = testing_guild_id
-
         self.initial_extensions = initial_extensions
 
     async def setup_hook(self) -> None:
         # Load in cogs
         for extension in self.initial_extensions:
             await self.load_extension(extension)
-
-        # Sync tree with testing guild
-        # Only do this to testing guild and not global
-        if self.testing_guild_id:
-            guild = discord.Object(self.testing_guild_id)
-            self.tree.copy_global_to(guild=guild)
-            await self.tree.sync(guild=guild)
 
         self.base_logger.info(
             f"Logged in as: {self.user.name} - {self.user.id}\tVersion: {discord.__version__}"
@@ -71,9 +61,7 @@ async def main():
             db_pool=pool,
             web_client=web_client,
             initial_extensions=exts,
-            # testing_guild_id=1012371257494360115,
         ) as bot:
-
             await bot.start(os.getenv("TOKEN"))
 
 


### PR DESCRIPTION
# Added command #9 

# Bot needs a method for syncing (current is flawed)

Discord slash commands are held on a tree. The tree needs to be synced with discord. This can either be done globally or per guild.

A command needs to be implemented. It can be called by mentioning the bot `sync`. The command can only be called in a guild and only by the owner of the bot. 

## Works like:
`@bot sync `-> global sync
`@bot sync ~` -> sync current guild
`@bot sync *` -> copies all global app commands to the current guild and syncs
`@bot sync ^` -> clears all commands from the current guild target and syncs (removes guild commands)
`@bot sync id_1 id_2` -> syncs guilds with id 1 and 2
where `bot` here is the name of the bot.

## Sync when you...
- Added/removed a command
- Changed a command's...
    - name (name= kwarg or function name)
    - description (description= kwarg or docstring)
- Added/removed an argument
- Changed an argument's...
    - name (rename decorator)
    - description (describe decorator)
    - type (arg: str str is the type here)
- Added/modified permissions:
    - guild_only decorator or kwarg
    - default_permissions decorator or kwarg
    - nsfw kwarg
- Converted the global/guild command to a guild/global command

## Do not sync when you...
- Changed anything in the function's body (after the async def (): part)
- Added or modified a library side check:
    - (@)app_commands.checks...
    - (@)commands...(.check)
    - @app_commands.checks.(dynamic_)cooldown(...)

This is the same for hybrid commands